### PR TITLE
Fix for Shadowlamb init and Dog commands like .svn

### DIFF
--- a/core/module/Dog/Dog.php
+++ b/core/module/Dog/Dog.php
@@ -39,6 +39,8 @@ final class Dog
 	
 	public static $IN_STARTUP = true;
 	
+	public static $FAKING_MESSAGE = false;
+	
 	#############
 	### Scope ###
 	#############
@@ -445,7 +447,11 @@ final class Dog
 		$from = self::$LAST_MSG->getFrom();
 		$to = $chan === false ? $serv->getNick()->getName() : $chan->getName();
 		$trigger = self::getTrigger();
+
+		$old = self::$FAKING_MESSAGE;
+		self::$FAKING_MESSAGE = true;
 		self::processMessage(self::getServer(), sprintf(':%s PRIVMSG %s :%s%s', $from, $to, $trigger, $message));
+		self::$FAKING_MESSAGE = $old;
 	}
 	
 	/**

--- a/core/module/Dog/dog_include/Dog_User.php
+++ b/core/module/Dog/dog_include/Dog_User.php
@@ -59,6 +59,11 @@ final class Dog_User extends GDO
 	
 	public function isFlooding($update=true)
 	{
+		if (Dog::$FAKING_MESSAGE)
+		{
+			return false;
+		}
+
 		$time = microtime(true);
 		$flood = Dog_Init::getFloodTime();
 		if (($this->last_msg + $flood) > $time)

--- a/core/module/Dog/dog_modules/dog_module/Shadowlamb/core/ai/extension/ext/customer.php
+++ b/core/module/Dog/dog_modules/dog_module/Shadowlamb/core/ai/extension/ext/customer.php
@@ -1,4 +1,5 @@
 <?php
+require_once 'equipper.php';
 class SR_AI_customer extends SR_AI_equipper
 {
 	public function ai_goal(SR_RealNPC $npc)


### PR DESCRIPTION
Git repository resulted in different order of files, exposing an implicit dependency. Added include.

Dog commands like .svn and .trac (without args) didn't return anything because they generated fake messages (e.g. '.help svn') that triggered the user's flood protection. Fixed by adding a static variable that indicates whether a fake message is being handled.