### PR TITLE
Nerfing icedorns

### DIFF
--- a/core/module/Dog/dog_modules/dog_module/Shadowlamb/spell/icedorn.php
+++ b/core/module/Dog/dog_modules/dog_module/Shadowlamb/spell/icedorn.php
@@ -16,7 +16,7 @@ final class Spell_icedorn extends SR_OffensiveSpell
 
 	public function cast(SR_Player $player, SR_Player $target, $level, $hits, SR_Player $potion_player)
 	{
-		$wis = $potion_player->get('wisdom') * 4;
+		$wis = $potion_player->get('wisdom') * 2;
 		$min = 5+$level*5;
 		$max = 10+$level*10+$wis;
 		$seconds = rand($min, $max);

--- a/core/module/Dog/dog_modules/dog_module/Shadowlamb/spell/icedorn.php
+++ b/core/module/Dog/dog_modules/dog_module/Shadowlamb/spell/icedorn.php
@@ -16,7 +16,7 @@ final class Spell_icedorn extends SR_OffensiveSpell
 
 	public function cast(SR_Player $player, SR_Player $target, $level, $hits, SR_Player $potion_player)
 	{
-		$wis = $potion_player->get('wisdom') * 30;
+		$wis = $potion_player->get('wisdom') * 4;
 		$min = 5+$level*5;
 		$max = 10+$level*10+$wis;
 		$seconds = rand($min, $max);


### PR DESCRIPTION
Without this icedorns is too overpowered, you can freeze an enemy for _a lot_ of time (basically, the first player casting icedorns will always win).
With this, if you can resist some hits you can continue and/or force the other player to cast again..
