### PR TITLE
Lamb3: Fix typo in english .facein translation

### DIFF
--- a/core/module/Dog/dog_plugins/dog_plugin/Auth/facein_Pb.php
+++ b/core/module/Dog/dog_plugins/dog_plugin/Auth/facein_Pb.php
@@ -1,7 +1,7 @@
 <?php
 $lang = array(
 	'en' => array(
-		'help' => 'Usage: %CMD% <email> <passwort>. Login with your facebook account.',
+		'help' => 'Usage: %CMD% <email> <password>. Login with your facebook account.',
 		'err_login' => 'Your username/password combination is unknown.',
 	),
 	'de' => array(


### PR DESCRIPTION
Fix a typo in the english translation of the .facein Lamb/Dog plugin