### PR TITLE
Wechall: Fix that changes link which is broken since ages

### DIFF
--- a/www/tpl/default/module/WeChall/wcfootermenu.php
+++ b/www/tpl/default/module/WeChall/wcfootermenu.php
@@ -3,7 +3,7 @@ $module = $tVars['module'];
 echo
 '<nav id="gwf_foot_menu">'.PHP_EOL.
 '<a href="'.GWF_WEB_ROOT.'news">'.$module->lang('menu_news').'</a>'.PHP_EOL.
-'| <a href="'.GWF_WEB_ROOT.'changes.txt">'.$module->lang('menu_changes').'</a>'.PHP_EOL.
+'| <a href="https://github.com/gizmore/gwf3/commits/master">'.$module->lang('menu_changes').'</a>'.PHP_EOL.
 '| <a href="'.GWF_WEB_ROOT.'about_wechall">'.$module->lang('menu_about').'</a>'.PHP_EOL.
 '| <a href="'.GWF_WEB_ROOT.'join_us">'.$module->lang('menu_join').'</a>'.PHP_EOL.
 '| <a href="'.GWF_WEB_ROOT.'links">'.$module->lang('menu_links').'</a>'.PHP_EOL.


### PR DESCRIPTION
That link used to go to `/changes.txt`, but that file got replaced by SVN,
and later by github. So why not just directly link to the github commit
log?