### PR TITLE
[Wechall] Fix ugly chall_head scrollbar

### DIFF
--- a/www/tpl/wc4/css/wechall4.css
+++ b/www/tpl/wc4/css/wechall4.css
@@ -720,7 +720,7 @@ form > .gwf_table > table {
 
 /** Challs **/
 .chall_head {
-	height: 24px;
+	height: 25px;
 	line-height: 24px;
 }
 


### PR DESCRIPTION
The chall_head element, showing the challenge meta data at the top,
rendered an ugly scrollbar (at least in chromium). To remove that the
height of the element is set to line-height + 1