### PR TITLE
Do not echo invalid PM deletion tokens

### DIFF
--- a/core/module/PM/method/Delete.php
+++ b/core/module/PM/method/Delete.php
@@ -12,8 +12,7 @@ final class PM_Delete extends GWF_Method
 		if (false === ($pm = GWF_PM::getByID($id))) {
 			return $this->module->error('err_pm');
 		}
-		if ($token != ($pm->getHashcode())) {
-			echo $pm->getHashcode();
+		if ($token !== $pm->getHashcode()) {
 			return $this->module->error('err_pm');
 		}
 		if (false === ($user = GWF_User::getByID($uid))) {


### PR DESCRIPTION
On PM deletion attempts with an invalid `token` parameter, the correct
token got echoed to the page.