### PR TITLE
[Shadowlamb] Fix motd path

### DIFF
--- a/core/module/Dog/dog_modules/dog_module/Shadowlamb/cmd/info/motd.php
+++ b/core/module/Dog/dog_modules/dog_module/Shadowlamb/cmd/info/motd.php
@@ -4,14 +4,13 @@ final class Shadowcmd_motd extends Shadowcmd
 	public static function execute(SR_Player $player, array $args)
 	{
 		$bot = Shadowrap::instance($player);
-		$path = Shadowrun4::getShadowDir().'dog_module/Shadowlamb/shadowlamb_motd.txt';
-		if (false === ($motd = @file_get_contents($path)))
+		$path = Shadowrun4::getShadowDir().'shadowlamb_motd.txt';
+		if (!is_readable($path) || false === ($motd = file_get_contents($path)))
 		{
-			$bot->reply('Can not read '.$path);
+			return $bot->reply('Can not read MOTD file');
 		}
 		return $bot->rply('5249', array($motd));
 // 		$bot->reply(sprintf('Message of the day: %s', $motd));
-// 		return true;
 	}
 }
 ?>


### PR DESCRIPTION
* The path to the shadowlamb `#motd` command was wrong, it repeated the
module path twice.
* Fixed full path disclosure: When unable to read the motd file, the
full path to it's supposed location was disclosed
* Remove error-suppression operator: The only case when this might be
possibly relevant is when the file is not readable, the PHP doc states
it "generates a WARNING" in that case. Added the `is_readable` check to
resolve this.
* Return early on not-found motd file. This avoids Having a message
`Message of the day: ` after the error message

Fixes issue #21