### PR TITLE
[Wechall] Fix sorting of linked_sited by solved count

### DIFF
--- a/core/module/WeChall/method/LinkedSites.php
+++ b/core/module/WeChall/method/LinkedSites.php
@@ -74,7 +74,7 @@ final class WeChall_LinkedSites extends GWF_Method
 	################
 	public function templateSites()
 	{
-		$whitelist = array('site_name', 'site_challcount', 'regat_score', 'site_score', 'regat_solved', 'regat_lastdate', 'regat_onsitename');
+		$whitelist = array('site_name', 'site_challcount', 'regat_score', 'site_score', 'regat_solved', 'regat_lastdate', 'regat_onsitename', 'regat_challsolved');
 		
 		$form_link = $this->getFormLink();
 		$form_all = $this->getFormAll();


### PR DESCRIPTION
The sorting on the linked sites overview page did not sort properly by
the _solved_ column. The sort parameter used there `regat_challsolved`,
was not whitelisted in the sorting fields.

Fixes issue #39 