### PR TITLE
fix busy time applied is 10 x time of effect

### DIFF
--- a/core/module/Dog/dog_modules/dog_module/Shadowlamb/spell/freeze.php
+++ b/core/module/Dog/dog_modules/dog_module/Shadowlamb/spell/freeze.php
@@ -21,7 +21,7 @@ final class Spell_freeze extends SR_OffensiveSpell
 		$max = 40+$level*20+$wis;
 		$seconds = rand($min, $max);
 		$seconds = $this->lowerSpellIncrement($target, $seconds, 'frozen');
-		$target->busy($seconds*10);
+		$target->busy($seconds);
 		$ef = Shadowfunc::diceFloat(0.1, $level, 1);
 		$target->addEffects(new SR_Effect($seconds, array('frozen'=>$ef), SR_Effect::MODE_ONCE_EXTEND));
 		$this->announceADV($player, $target, $level, '10050', $seconds, $ef);

--- a/core/module/Dog/dog_modules/dog_module/Shadowlamb/spell/icedorn.php
+++ b/core/module/Dog/dog_modules/dog_module/Shadowlamb/spell/icedorn.php
@@ -21,7 +21,7 @@ final class Spell_icedorn extends SR_OffensiveSpell
 		$max = 10+$level*10+$wis;
 		$seconds = rand($min, $max);
 		$seconds = $this->lowerSpellIncrement($target, $seconds, 'frozen');
-		$target->busy($seconds*10);
+		$target->busy($seconds);
 		$ef = Shadowfunc::diceFloat(0.1, $level, 1);
 		$target->addEffects(new SR_Effect($seconds, array('frozen'=>$ef), SR_Effect::MODE_ONCE_EXTEND));
 		


### PR DESCRIPTION
This _should_ fix the problems with freeze/icedorn spells, as mentioned in #3 e.g.
Need a Shadowlamb pro coder to approve.