### PR TITLE
Fix `2021 Christmas Grampa` link

### DIFF
--- a/www/challenge/christmas2021/grampa/lang/chall_en.php
+++ b/www/challenge/christmas2021/grampa/lang/chall_en.php
@@ -8,6 +8,5 @@ $lang = array(
 		'The problem is that he will need glasses.<br/>'.PHP_EOL.
 		'Do you need glasses as well?<br/>'.PHP_EOL.
 		'<br/>'.PHP_EOL.
-		'spaceone told us you can <a href="%s">help!<br/>'.PHP_EOL,
-	
+		'spaceone told us you can <a href="%s">help!</a><br/>'.PHP_EOL,
 );


### PR DESCRIPTION
The link tag was not closed, causing even focusing on the input field to open the link target.