### PR TITLE
Fix `GFW_HTTP::pageExists()` for HTTP 2 responses

### DIFF
--- a/core/inc/util/GWF_HTTP.php
+++ b/core/inc/util/GWF_HTTP.php
@@ -95,7 +95,7 @@ final class GWF_HTTP
 		curl_close($ch);
 		
 		# Get the status code from HTTP headers
-		if(preg_match('/HTTP\/1\.\d+\s+(\d+)/', $response, $matches))
+		if(preg_match('/HTTP\/((1\.\d+)|2)\s+(\d+)/', $response, $matches))
 		{
 			$code = intval($matches[1]);
   		} 


### PR DESCRIPTION
Trying to check a site responding with HTTP/2 obviously doesn't work with this...