### PR TITLE
Replace deprecated curly brace syntax

### DIFF
--- a/core/inc/util/GWF_Crypt.php
+++ b/core/inc/util/GWF_Crypt.php
@@ -32,7 +32,7 @@ final class GWF_Crypt
 					$x = 1;
 				}
 			}
-			$back .= chr(ord($key{$k%$klen}) ^ ord($ciphertext{$i}) ^ $e);
+			$back .= chr(ord($key[$k%$klen]) ^ ord($ciphertext[$i]) ^ $e);
 		}
 		return $back;
 	}

--- a/core/inc/util/GWF_Numeric.php
+++ b/core/inc/util/GWF_Numeric.php
@@ -162,7 +162,7 @@ final class GWF_Numeric
 		$len = strlen($n);
 		for ($i = 0; $i < $len; $i++)
 		{
-			$sum += (int)$n{$i};
+			$sum += (int)$n[$i];
 		}
 		return $sum;
 	}

--- a/core/inc/util/GWF_StringPermutation.php
+++ b/core/inc/util/GWF_StringPermutation.php
@@ -14,7 +14,7 @@ final class GWF_StringPermutation extends GWF_Permutation
 		$back = '';
 		foreach ($a as $i)
 		{
-			$back .= $this->string{$i};
+			$back .= $this->string[$i];
 		}
 		return $back;
 	}

--- a/core/module/Dog/lamb_module/PG/Mod_PG.php
+++ b/core/module/Dog/lamb_module/PG/Mod_PG.php
@@ -89,7 +89,7 @@ final class DOGMOD_PG extends Dog_Module
 		$len = strlen($message);
 		for ($i = 0; $i < $len; $i++)
 		{
-			$c = $message{$i};
+			$c = $message[$i];
 			if ($c >= 'a' && $c <= 'z')
 			{
 				$lower++;

--- a/www/challenge/hashgame/hg_wc4.php
+++ b/www/challenge/hashgame/hg_wc4.php
@@ -8,7 +8,7 @@ function hashgame_wc4_salt($len = 4)
 	$back = '';
 	for ($i = 0; $i < $len; $i++)
 	{
-		$back .= $alpha{rand(0, $max)};
+		$back .= $alpha[rand(0, $max)];
 	}
 	return $back;
 }

--- a/www/challenge/noother/php0818/php0818.php
+++ b/www/challenge/noother/php0818/php0818.php
@@ -26,7 +26,7 @@ function noother_says_correct($number)
 	for ($i = 0; $i < strlen($number); $i++)
 	{ 
 		# Disallow all the digits!
-		$digit = ord($number{$i});
+		$digit = ord($number[$i]);
 		if ( ($digit >= $one) && ($digit <= $nine) )
 		{
 			# Aha, digit not allowed!

--- a/www/challenge/training/crypto/caesar/index.php
+++ b/www/challenge/training/crypto/caesar/index.php
@@ -44,7 +44,7 @@ function crypto_caesar_1_encrypt($pt)
 	$len = strlen($pt);
 	for ($i = 0; $i < $len; $i++)
 	{
-		$c = $pt{$i};
+		$c = $pt[$i];
 		if ($c === ' ') {
 			$ct .= ' ';
 		} else {

--- a/www/challenge/training/crypto/caesar2/index.php
+++ b/www/challenge/training/crypto/caesar2/index.php
@@ -44,7 +44,7 @@ function crypto_caesar_2_encrypt($pt)
 	$len = strlen($pt);
 	for ($i = 0; $i < $len; $i++)
 	{
-		$c = $pt{$i};
+		$c = $pt[$i];
 		if ($c === ' ') {
 			$ct .= $c;
 		} else {

--- a/www/challenge/training/crypto/digraph/index.php
+++ b/www/challenge/training/crypto/digraph/index.php
@@ -41,7 +41,7 @@ function crypto_dig1_encrypt($pt)
 	$len = strlen($pt);
 	for ($i = 0; $i < $len; $i++)
 	{
-		$c = $pt{$i};
+		$c = $pt[$i];
 		if ($c === ' ') {
 			$ct .= ' ';
 		} else {

--- a/www/challenge/training/crypto/simplesub1/index.php
+++ b/www/challenge/training/crypto/simplesub1/index.php
@@ -56,7 +56,7 @@ function crypto_sub1_encrypt($pt, array $map)
 	$len = strlen($pt);
 	for ($i = 0; $i < $len; $i++)
 	{
-		$c = $pt{$i};
+		$c = $pt[$i];
 		if ($c === ' ') {
 			$ct .= ' ';
 		} else {

--- a/www/challenge/training/crypto/simplesub2/index.php
+++ b/www/challenge/training/crypto/simplesub2/index.php
@@ -53,7 +53,7 @@ function crypto_sub2_encrypt($pt, array $map)
 	$len = strlen($pt);
 	for ($i = 0; $i < $len; $i++)
 	{
-		$c = $pt{$i};
+		$c = $pt[$i];
 // 		if ($c === ' ') {
 // 			$ct .= ' ';
 // 		} else {

--- a/www/challenge/training/crypto/transposition1/index.php
+++ b/www/challenge/training/crypto/transposition1/index.php
@@ -45,8 +45,8 @@ function crypto_trans1_encrypt($pt)
 	$ct = '';
 	while ($i < $len)
 	{
-		$ct .= $pt{$i+1};
-		$ct .= $pt{$i};
+		$ct .= $pt[$i+1];
+		$ct .= $pt[$i];
 		$i += 2;
 	}
 	return $ct;

--- a/www/challenge/training/encodings/ascii/index.php
+++ b/www/challenge/training/encodings/ascii/index.php
@@ -19,7 +19,7 @@ $message = '';
 $len = strlen($msg);
 for ($i = 0; $i < $len; $i++)
 {
-	$message .= ', '.ord($msg{$i});
+	$message .= ', '.ord($msg[$i]);
 }
 $message = substr($message, 2);
 

--- a/www/challenge/training/encodings/bacon2/index.php
+++ b/www/challenge/training/encodings/bacon2/index.php
@@ -46,7 +46,7 @@ function bacon2_to_stream($hidden)
 	$len = strlen($hidden);
 	for ($i = 0; $i < $len; $i++)
 	{
-		$c = ord($hidden{$i}) - $a;
+		$c = ord($hidden[$i]) - $a;
 		$back .= sprintf('%05d', decbin($c));
 	}
 	return $back;
@@ -71,11 +71,11 @@ function bacon2_encode(WC_Challenge $chall, $hidden)
 		}
 
 		# current char in carrier
-		$curr = $message{$pos};
+		$curr = $message[$pos];
 		if ($curr >= 'a' && $curr <= 'z')
 		{
 			# what char do we need
-			switch ($hiddenstream{$si})
+			switch ($hiddenstream[$si])
 			{
 				case '0':
 					if ($curr >= 'n') { # we need a 0 but fail

--- a/www/challenge/training/encodings/url/index.php
+++ b/www/challenge/training/encodings/url/index.php
@@ -15,7 +15,7 @@ $message = '';
 $len = strlen($msg);
 for ($i = 0; $i < $len; $i++)
 {
-	$message .= sprintf('%%%02X', ord($msg{$i}));
+	$message .= sprintf('%%%02X', ord($msg[$i]));
 }
 echo GWF_Box::box($chall->lang('info', array($message)), $chall->lang('title'));
 formSolutionbox($chall);


### PR DESCRIPTION
Curly braces for accessing string or array offsets have been deprecated since PHP 7.4, and removed in PHP 8.0.

See: https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.core.other