### PR TITLE
Dog: Define undefined properties

### DIFF
--- a/core/module/Dog/dog_include/Dog_WorkerThread.php
+++ b/core/module/Dog/dog_include/Dog_WorkerThread.php
@@ -29,6 +29,7 @@ final class Dog_WorkerThread
 	private $max_msg_len = 65535;
 	
 	// Callbacks
+	private $callmxtim = 300;
 	private $callb_max = 3;   // max queued jobs at once
 	private $callbacks = array();
 	private $callbacnt = 1;

--- a/core/module/Dog/dog_modules/dog_module/Shadowlamb/core/ai/SR_NPCBase.php
+++ b/core/module/Dog/dog_modules/dog_module/Shadowlamb/core/ai/SR_NPCBase.php
@@ -12,7 +12,9 @@ abstract class SR_NPCBase extends SR_Player
 	 * @var SR_Player
 	 */
 	protected $chat_partner = NULL;
-	
+
+	private $npc_classname;
+
 	public function hasFeelings() { return false; }
 	public function hasRottingItems() { return false; }
 	


### PR DESCRIPTION
Writing to properties which don't exist is no longer supported in PHP 8.2.

Defined them.