### PR TITLE
Remove wixxerd.com solved-announcement poller

### DIFF
--- a/core/module/Dog/dog_timer/all_servers_one/timers/infinity/30/solvers_wix.php
+++ b/core/module/Dog/dog_timer/all_servers_one/timers/infinity/30/solvers_wix.php
@@ -1,6 +1,0 @@
-<?php
-require_once DOG_PATH.'dog_lib/Dog_WC_Solvers.php';
-$url = 'http://www.wixxerd.com/challenges/recentlysolved.cfm?cdate=%DATE%';
-$format = "%1\$s \x02%2\$s\x02 has just solved \x02%3\$s\x02. This challenge has been solved %4\$d times. (%5\$s)";
-dog_wc_solvers('wixxerd', '[wixxerd]', $url, array('#wixxerd'), 100, $format);
-?>


### PR DESCRIPTION
The site is dead, this uselessly polls some non-existing URL and spams the log.