### PR TITLE
Set *last updated* date of a site to the *link date* on link

### DIFF
--- a/core/module/WeChall/method/LinkedSites.php
+++ b/core/module/WeChall/method/LinkedSites.php
@@ -295,6 +295,7 @@ final class WeChall_LinkedSites extends GWF_Method
 			'regat_langid' => $site->getLangID(),
 			'regat_tagbits' => $site->getTagBits(),
 			'regat_linkdate' => GWF_Time::getDate(GWF_Date::LEN_DAY),
+			'regat_lastdate' => GWF_Time::getDate(GWF_Date::LEN_DAY),
 		));
 		if (false === ($regat->insert()))
 		{


### PR DESCRIPTION
This fixes a crash on linking a new site, when working with MySql 8 and its default settings:

```
12:31 [172.20.0.1:admin] - GDO Error(1364): Field 'regat_lastdate' doesn't have a default value
INSERT INTO `gwf3_wc_regat` (`regat_uid`,`regat_sid`,`regat_onsitename`,`regat_onsitescore`,`regat_challcount`,`regat_options`,`regat_langid`,`regat_tagbits`,`regat_linkdate`) VALUES ('3','1','admin','0','0','0','1','15','20240616')
```


Leaving the `regat_lastdate` column undefined on INSERT errors with MySql 8 due to the column not having a default value.

Since the date logic is custom, and might not work with NULL, and I don't have any idea how to do DB migrations in this, the simplest solution is to set it to the same value as the link date. That's not logically wrong either.

It _is_ a behavior change tho.