### PR TITLE
WeChall: Fix non-replaced placeholder in Stalking error message

### DIFF
--- a/www/challenge/identity/stalking/index.php
+++ b/www/challenge/identity/stalking/index.php
@@ -23,7 +23,7 @@ if (false === ($identity = WC_Challenge::getByTitle('Identity')))
 else if (!WC_ChallSolved::hasSolved($user->getID(), $identity->getID()))
 {
 	$ida = sprintf('<a href="%s">%s</a>', htmlspecialchars($identity->hrefChallenge()), htmlspecialchars($identity->getName()));
-	echo GWF_HTML::error($chall->lang('title'), $chall->lang('err_identity', $ida));
+	echo GWF_HTML::error($chall->lang('title'), $chall->lang('err_identity', [$ida]));
 }
 
 else # We can submit answers 


### PR DESCRIPTION
If you visit the `Stalking` challenge without having solved the `Identity` challenge before, or are just not logged in, the error message rendered is:

> Please solve the %s challenge first.

Other usages of the `$chall->lang()` indicate an array there, so this _might_ fix it (untested).