### PR TITLE
Fix typo in wechall birthdays module

### DIFF
--- a/core/module/WeChall/Module_WeChall.php
+++ b/core/module/WeChall/Module_WeChall.php
@@ -430,7 +430,7 @@ final class Module_WeChall extends GWF_Module
 				$day = '[b]'.WC_HTML::lang('Today').'[/b]';
 			}
 			elseif ($date === $tomorrow) {
-				$day = WC_HTML::lang('Tommorow');
+				$day = WC_HTML::lang('Tomorrow');
 			}
 			elseif ($date < $today) {
 				$day = WC_HTML::lang('bd_over', array($day));

--- a/core/module/WeChall/lang/wechall/_wc_cs.php
+++ b/core/module/WeChall/lang/wechall/_wc_cs.php
@@ -76,6 +76,7 @@ $lang = array(
 	'bdnews_body_init' => 'Tito uživatelé mají tento týden narozeniny:'.PHP_EOL.'[url=%s]Označ jako přečtené[/url]'.PHP_EOL.PHP_EOL,
 	'Yesterday' => 'Včera',
 	'Today' => 'Dnes',
+	'Tomorrow' => 'Zítra',
 	'Yesterday' => 'Včera',
 	'OtherDay' => 'Tento %s',
 

--- a/core/module/WeChall/lang/wechall/_wc_cs.php
+++ b/core/module/WeChall/lang/wechall/_wc_cs.php
@@ -77,7 +77,6 @@ $lang = array(
 	'Yesterday' => 'Včera',
 	'Today' => 'Dnes',
 	'Tomorrow' => 'Zítra',
-	'Yesterday' => 'Včera',
 	'OtherDay' => 'Tento %s',
 
 	'fav_links' => '%s ma %s oblíbených odkazů',

--- a/core/module/WeChall/lang/wechall/_wc_de.php
+++ b/core/module/WeChall/lang/wechall/_wc_de.php
@@ -76,6 +76,7 @@ $lang = array(
 	'bdnews_body_init' => 'Die folgenden Benutzer haben diese Woche Geburtstag:'.PHP_EOL.'[url=%s]Hier klicken um die News als gelesen zu markieren[/url]'.PHP_EOL.PHP_EOL,
 	'Yesterday' => 'Gestern',
 	'Today' => 'Heute',
+	'Tomorrow' => 'Morgen',
 	'OtherDay' => 'Diesen %s',
 
 	'fav_links' => '%s hat %s Lieblings-Links',

--- a/core/module/WeChall/lang/wechall/_wc_en.php
+++ b/core/module/WeChall/lang/wechall/_wc_en.php
@@ -76,7 +76,6 @@ $lang = array(
 	'Yesterday' => 'Yesterday',
 	'Today' => 'Today',
 	'Tomorrow' => 'Tomorrow',
-	'Yesterday' => 'Yesterday',
 	'OtherDay' => 'This %s',
 
 	'fav_links' => '%s has %s favorite Links',

--- a/core/module/WeChall/lang/wechall/_wc_en.php
+++ b/core/module/WeChall/lang/wechall/_wc_en.php
@@ -75,6 +75,7 @@ $lang = array(
 	'bdnews_body_init' => 'The following users have birthday this week:'.PHP_EOL.'[url=%s]Click here to mark these read[/url]'.PHP_EOL.PHP_EOL,
 	'Yesterday' => 'Yesterday',
 	'Today' => 'Today',
+	'Tomorrow' => 'Tomorrow',
 	'Yesterday' => 'Yesterday',
 	'OtherDay' => 'This %s',
 

--- a/core/module/WeChall/lang/wechall/_wc_es.php
+++ b/core/module/WeChall/lang/wechall/_wc_es.php
@@ -76,6 +76,7 @@ $lang = array(
     'bdnews_body_init' => 'Los siguientes usuarios cumplen años esta semana:'.PHP_EOL.'[url=%s]Clic aquí para marcar como leído[/url]'.PHP_EOL.PHP_EOL,
     'Yesterday' => 'Ayer',
     'Today' => 'Hoy',
+    'Tomorrow' => 'Mañana',
     'Yesterday' => 'Ayer',
     'OtherDay' => 'Este %s',
 

--- a/core/module/WeChall/lang/wechall/_wc_es.php
+++ b/core/module/WeChall/lang/wechall/_wc_es.php
@@ -77,7 +77,6 @@ $lang = array(
     'Yesterday' => 'Ayer',
     'Today' => 'Hoy',
     'Tomorrow' => 'Mañana',
-    'Yesterday' => 'Ayer',
     'OtherDay' => 'Este %s',
 
     'fav_links' => '%s tiene %s enlaces favoritos',

--- a/core/module/WeChall/lang/wechall/_wc_fr.php
+++ b/core/module/WeChall/lang/wechall/_wc_fr.php
@@ -79,6 +79,7 @@ $lang = array(
 	'bdnews_body_init' => 'Les utilisateurs suivants ont fêté leur anniversaire cette semaine:'.PHP_EOL.'[url=%s]Cliquez ici pour marquer comme lu[/url]'.PHP_EOL.PHP_EOL,
 	'Yesterday' => 'Hier',
 	'Today' => 'Aujourd\'hui',
+	'Tomorrow' => 'Demain',
 	'Yesterday' => 'Hier',
 	'OtherDay' => 'Ce %s',
 

--- a/core/module/WeChall/lang/wechall/_wc_fr.php
+++ b/core/module/WeChall/lang/wechall/_wc_fr.php
@@ -80,7 +80,6 @@ $lang = array(
 	'Yesterday' => 'Hier',
 	'Today' => 'Aujourd\'hui',
 	'Tomorrow' => 'Demain',
-	'Yesterday' => 'Hier',
 	'OtherDay' => 'Ce %s',
 
 	'fav_links' => '%s a %s liens favoris',

--- a/core/module/WeChall/lang/wechall/_wc_hu.php
+++ b/core/module/WeChall/lang/wechall/_wc_hu.php
@@ -75,6 +75,7 @@ $lang = array(
 	'bdnews_body_init' => 'A következő felhasználóknak van a héten születésnapjuk:'.PHP_EOL.'[url=%s]Kattints ide, hogy olvasottként jelöld meg ezt az üzenetet.[/url]'.PHP_EOL.PHP_EOL,
 	'Yesterday' => 'Tegnap',
 	'Today' => 'Ma',
+	'Tomorrow' => 'Holnap',
 	'Yesterday' => 'Tegnap',
 	'OtherDay' => 'Ez %s',
 

--- a/core/module/WeChall/lang/wechall/_wc_hu.php
+++ b/core/module/WeChall/lang/wechall/_wc_hu.php
@@ -76,7 +76,6 @@ $lang = array(
 	'Yesterday' => 'Tegnap',
 	'Today' => 'Ma',
 	'Tomorrow' => 'Holnap',
-	'Yesterday' => 'Tegnap',
 	'OtherDay' => 'Ez %s',
 
 	'fav_links' => '%s felhasználó %s kedvenc linket jelölt be',

--- a/core/module/WeChall/lang/wechall/_wc_it.php
+++ b/core/module/WeChall/lang/wechall/_wc_it.php
@@ -75,6 +75,7 @@ $lang = array(
 	'bdnews_body_init' => 'I seguenti utenti hanno compiuto gli anni questa settimana:'.PHP_EOL.'[url=%s]Clicca qui per impostare il messaggio come letto[/url]'.PHP_EOL.PHP_EOL,
 	'Yesterday' => 'Ieri',
 	'Today' => 'Oggi',
+	'Tomorrow' => 'Domani',
 	'Yesterday' => 'Domani',
 	'OtherDay' => 'Questo %s',
 

--- a/core/module/WeChall/lang/wechall/_wc_it.php
+++ b/core/module/WeChall/lang/wechall/_wc_it.php
@@ -76,7 +76,6 @@ $lang = array(
 	'Yesterday' => 'Ieri',
 	'Today' => 'Oggi',
 	'Tomorrow' => 'Domani',
-	'Yesterday' => 'Domani',
 	'OtherDay' => 'Questo %s',
 
 	'fav_links' => '%s ha %s link favoriti',

--- a/core/module/WeChall/lang/wechall/_wc_ru.php
+++ b/core/module/WeChall/lang/wechall/_wc_ru.php
@@ -75,6 +75,7 @@ $lang = array(
 	'bdnews_body_init' => 'Следующие пользователи празднуют свой день рождения на этой недели:'.PHP_EOL.'[url=%s]Нажмите здесь,чтобы отметить их[/url]'.PHP_EOL.PHP_EOL,
 	'Yesterday' => 'Вчера',
 	'Today' => 'Сегодня',
+	'Tomorrow' => 'Завтра',
 	'Yesterday' => 'Вчера',
 	'OtherDay' => 'На днях %s',
 

--- a/core/module/WeChall/lang/wechall/_wc_ru.php
+++ b/core/module/WeChall/lang/wechall/_wc_ru.php
@@ -76,7 +76,6 @@ $lang = array(
 	'Yesterday' => 'Вчера',
 	'Today' => 'Сегодня',
 	'Tomorrow' => 'Завтра',
-	'Yesterday' => 'Вчера',
 	'OtherDay' => 'На днях %s',
 
 	'fav_links' => '%s имеет %s любимые ссылки',

--- a/core/module/WeChall/lang/wechall/_wc_sr.php
+++ b/core/module/WeChall/lang/wechall/_wc_sr.php
@@ -77,7 +77,6 @@ $lang = array(
 	'Yesterday' => 'Јуче',
 	'Today' => 'Данас',
 	'Tomorrow' => 'Tomorrow',
-	'Yesterday' => 'Јуче',
 	'OtherDay' => 'This %s',
 
 	'fav_links' => '%s has %s favorite Links',

--- a/core/module/WeChall/lang/wechall/_wc_sr.php
+++ b/core/module/WeChall/lang/wechall/_wc_sr.php
@@ -76,6 +76,7 @@ $lang = array(
 	'bdnews_body_init' => 'Следећи корисници имају рођендан ове недеље:'.PHP_EOL.'[url=%s]Кликните овде да означите као прочитано[/url]'.PHP_EOL.PHP_EOL,
 	'Yesterday' => 'Јуче',
 	'Today' => 'Данас',
+	'Tomorrow' => 'Tomorrow',
 	'Yesterday' => 'Јуче',
 	'OtherDay' => 'This %s',
 


### PR DESCRIPTION
- Fix typo in `tommorow`
- added translations for it (de/en/es/fr manual, rest is deepl-provided translations)
- also fixed duplicate `yesterday` key in translations