### PR TITLE
wechall: Add missing translations for `th_no_email`

### DIFF
--- a/core/module/WeChall/lang/wechall/_wc_cs.php
+++ b/core/module/WeChall/lang/wechall/_wc_cs.php
@@ -806,4 +806,7 @@ tým WeChall',
         Of course it's better to use a real client like kvirc.<br/>\n
         <br/>\n
         Click this link to start the chat: %s.<br/>\n",
+
+    # admin "edit site"
+    'th_no_email' => 'Web neukládá žádné e-maily pro uživatele',
 );

--- a/core/module/WeChall/lang/wechall/_wc_de.php
+++ b/core/module/WeChall/lang/wechall/_wc_de.php
@@ -808,4 +808,7 @@ Das WeChall-Team',
         Of course it's better to use a real client like kvirc.<br/>\n
         <br/>\n
         Click this link to start the chat: %s.<br/>\n",
+
+    # admin "edit site"
+    'th_no_email' => 'Site speichert keine Nutzer-emails',
 );

--- a/core/module/WeChall/lang/wechall/_wc_en.php
+++ b/core/module/WeChall/lang/wechall/_wc_en.php
@@ -806,4 +806,7 @@ The WeChall Team',
         Of course it's better to use a real client like kvirc.<br/>\n
         <br/>\n
         Click this link to start the chat: %s.<br/>\n",
+
+    # admin "edit site"
+    'th_no_email' => 'Site saves no e-mails for users',
 );

--- a/core/module/WeChall/lang/wechall/_wc_es.php
+++ b/core/module/WeChall/lang/wechall/_wc_es.php
@@ -806,4 +806,7 @@ El equipo de WeChall',
         Of course it's better to use a real client like kvirc.<br/>\n
         <br/>\n
         Click this link to start the chat: %s.<br/>\n",
+
+    # admin "edit site"
+    'th_no_email' => 'El sitio no guarda correos electrónicos para los usuarios',
 );

--- a/core/module/WeChall/lang/wechall/_wc_fr.php
+++ b/core/module/WeChall/lang/wechall/_wc_fr.php
@@ -809,4 +809,7 @@ L\'équipe WeChall',
         Of course it's better to use a real client like kvirc.<br/>\n
         <br/>\n
         Click this link to start the chat: %s.<br/>\n",
+
+    # admin "edit site"
+    'th_no_email' => "Le site n'enregistre pas d'e-mails pour les utilisateurs",
 );

--- a/core/module/WeChall/lang/wechall/_wc_hu.php
+++ b/core/module/WeChall/lang/wechall/_wc_hu.php
@@ -802,4 +802,7 @@ A WeChall csapata',
         Of course it's better to use a real client like kvirc.<br/>\n
         <br/>\n
         Click this link to start the chat: %s.<br/>\n",
+
+    # admin "edit site"
+    'th_no_email' => 'A webhely nem tárolja a felhasználók e-mailjeit',
 );

--- a/core/module/WeChall/lang/wechall/_wc_it.php
+++ b/core/module/WeChall/lang/wechall/_wc_it.php
@@ -805,4 +805,7 @@ Il team WeChall',
         Of course it's better to use a real client like kvirc.<br/>\n
         <br/>\n
         Click this link to start the chat: %s.<br/>\n",
+
+    # admin "edit site"
+    'th_no_email' => 'Il sito non salva le e-mail degli utenti',
 );

--- a/core/module/WeChall/lang/wechall/_wc_ru.php
+++ b/core/module/WeChall/lang/wechall/_wc_ru.php
@@ -805,4 +805,7 @@ The WeChall Team<br/>
         Of course it's better to use a real client like kvirc.<br/>\n
         <br/>\n
         Click this link to start the chat: %s.<br/>\n",
+
+    # admin "edit site"
+    'th_no_email' => 'Сайт не сохраняет электронные письма для пользователей',
 );

--- a/core/module/WeChall/lang/wechall/_wc_sr.php
+++ b/core/module/WeChall/lang/wechall/_wc_sr.php
@@ -806,4 +806,7 @@ The WeChall Team<br/>
         Of course it's better to use a real client like kvirc.<br/>\n
         <br/>\n
         Click this link to start the chat: %s.<br/>\n",
+
+    # admin "edit site"
+    'th_no_email' => 'Site saves no e-mails for users',
 );


### PR DESCRIPTION
wechall: Add missing translations for `th_no_email`

This is a setting name in the `Edit Site` Form:

![Image](https://github.com/user-attachments/assets/44554b9e-21cd-4834-811d-65ee3d37808d) 

