### PR TITLE
Wechall: Update max score for HTS

### DIFF
--- a/core/module/WeChall/sites/WCSite_HTS.php
+++ b/core/module/WeChall/sites/WCSite_HTS.php
@@ -14,18 +14,21 @@ final class WCSite_HTS extends WC_Site
 			return htmlDisplayError(WC_HTML::lang('err_response', array(GWF_HTML::display($result), $this->displayName())));
 		}
 		
-		$onsitescore = intval($stats[2]);
+		$onsitescore = intval($stats[2]);   // this is always 6713 - probably was a max score once?
 		$score = intval($stats[1]);
-		$rankname = $stats[0]; 
+		$rankname = $stats[0];
+		// max score from https://www.hackthissite.org/user/rankings/explanation
+		// note: users might still have higher scores, as e.g. finding a vuln gives points, too
+		$maxScore = 10533;
 		$usercount = 39500;
-		$challcount = 102; #intval($stats[3]);
+		$challcount = 107; #intval($stats[3]);
 		
 		if ( ($score > ($onsitescore * 2)) || ($challcount <= 2) || ($onsitescore < 0))
 		{
 			return htmlDisplayError(WC_HTML::lang('err_response', array(GWF_HTML::display($result), $this->displayName())));
 		}
 		
-		return array($score, -1, -1, $onsitescore, $usercount, $challcount);
+		return array($score, -1, -1, $maxScore, $usercount, $challcount);
 	}
 }
 ?>


### PR DESCRIPTION
A lot of users have > 100% reported.

It seems that the "onsitescore" variable, which was returned as "maxscore" was way too low. Calculated a current potential max score from https://www.hackthissite.org/user/rankings/explanation and used this.

Updated the chall count, too.

Thanks Munto for pointing to the ranking explanation page.

PS: This is yet another workaround. Maybe we can get things working correctly art some point with #32 