### PR TITLE
Shadowlamb: Fix quest-related single-vararg i18n calls

### DIFF
--- a/core/module/Dog/dog_modules/dog_module/Shadowlamb/city/Seattle/quest/Seattle_Farmer.php
+++ b/core/module/Dog/dog_modules/dog_module/Shadowlamb/city/Seattle/quest/Seattle_Farmer.php
@@ -18,7 +18,7 @@ final class Quest_Seattle_Farmer extends SR_Quest
 		}
 		else
 		{
-			return $npc->reply($this->lang('more', max(0, $this->getNeededAmount()-$this->getAmount())));
+			return $npc->reply($this->lang('more', array(max(0, $this->getNeededAmount()-$this->getAmount()))));
 		}
 	}
 	

--- a/core/module/Dog/dog_modules/dog_module/Shadowlamb/city/Vegas/quest/Vegas_DarkBonds.php
+++ b/core/module/Dog/dog_modules/dog_module/Shadowlamb/city/Vegas/quest/Vegas_DarkBonds.php
@@ -21,7 +21,7 @@ final class Quest_Vegas_DarkBonds extends SR_QuestMultiItem
 		{
 			case 'shadowrun':
 				$npc->rply($this->lang('1'));
-				$npc->rply($this->lang('2', $this->getQuestDescriptionStats()));
+				$npc->rply($this->lang('2', array($this->getQuestDescriptionStats())));
 				$npc->rply($this->lang('3'));
 				break;
 			case 'confirm':

--- a/core/module/Dog/dog_modules/dog_module/Shadowlamb/city/Vegas/quest/Vegas_HiJack.php
+++ b/core/module/Dog/dog_modules/dog_module/Shadowlamb/city/Vegas/quest/Vegas_HiJack.php
@@ -14,7 +14,7 @@ final class Quest_Vegas_HiJack extends SR_QuestMultiItem
 		{
 			case 'shadowrun':
 				$npc->rply($this->lang('1'));
-				$npc->rply($this->lang('2', $this->getQuestDescriptionStats()));
+				$npc->rply($this->lang('2', array($this->getQuestDescriptionStats())));
 				$npc->rply($this->lang('3'));
 				break;
 			case 'confirm':

--- a/core/module/Dog/dog_modules/dog_module/Shadowlamb/city/Vegas/quest/Vegas_Ringdom.php
+++ b/core/module/Dog/dog_modules/dog_module/Shadowlamb/city/Vegas/quest/Vegas_Ringdom.php
@@ -35,7 +35,7 @@ final class Quest_Vegas_Ringdom extends SR_QuestMultiItem
 		{
 			case 'shadowrun':
 				$npc->rply($this->lang('1'));
-				$npc->rply($this->lang('2', $this->getQuestDescriptionStats()));
+				$npc->rply($this->lang('2', array($this->getQuestDescriptionStats())));
 				break;
 			case 'confirm':
 				$npc->rply($this->lang('3'));


### PR DESCRIPTION
A few `lang()` calls are missing `array` wrappers when used with a single argument, this should fix all of them.

Example of current output:
```
#talk 1
Joe says: "Please, protect my sheep! You still need to kill %s more MonsterWerewolfs!"
```

P.S. It is ironic to see [incorrect usage](https://github.com/gizmore/gwf3/blob/b1512aabfc28476f77daa05eb774fadfbf7804fa/core/module/Dog/dog_modules/dog_module/Shadowlamb/city/Vegas/quest/Vegas_DarkBonds.php#L24) just a few lines below [the correct one](https://github.com/gizmore/gwf3/blob/b1512aabfc28476f77daa05eb774fadfbf7804fa/core/module/Dog/dog_modules/dog_module/Shadowlamb/city/Vegas/quest/Vegas_DarkBonds.php#L13).
