### PR TITLE
Fix method return type error impacting What is your name challenge

### DIFF
--- a/core/module/WeChall/WC_Warbox.php
+++ b/core/module/WeChall/WC_Warbox.php
@@ -45,7 +45,7 @@ final class WC_Warbox extends GDO
 		);
 	}
 
-	public static function getByName(string $name): WC_Warbox { return WC_Warbox::table('WC_Warbox')->getBy('wb_name', $name); }
+	public static function getByName(string $name) { return WC_Warbox::table('WC_Warbox')->getBy('wb_name', $name); }
 	public function getID() { return $this->getVar('wb_id'); }
 	public function getSite() { return new WCSite_WARBOX($this->gdo_data); }
 	public function getSiteID() { return $this->getVar('wb_sid'); }


### PR DESCRIPTION
Fixing error on page https://www.wechall.net/en/challenge/Mawekl/what_is_your_name/who.php :  

```
Parse error: syntax error, unexpected ':', expecting ';' or '{' in /home/wechall/www/wc5/core/module/WeChall/WC_Warbox.php on line 48
PHP Fatal Error(1): syntax error, unexpected ':', expecting ';' or '{' in core/module/WeChall/WC_Warbox.php line 48
```

