### PR TITLE
fix(GWF_BBCode): add target="_blank" only for absoulute URIs

### DIFF
--- a/core/inc/util/GWF_BBCodeItem.php
+++ b/core/inc/util/GWF_BBCodeItem.php
@@ -371,7 +371,11 @@ final class GWF_BBCodeItem
 
 		$text = $this->filterURLText($text);
 
-		return sprintf('<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>', $the_href, $text);
+		$is_absolute = GWF_Validator::isAbsoluteURL($url);
+		$target = $is_absolute ? '_blank' : '_self';
+		$rel = $is_absolute ? ' rel="noopener noreferrer"' : '';
+
+		return sprintf('<a href="%s" target="%s"%s>%s</a>', $the_href, $target, $rel, $text);
 	}
 
 	public function render_php($htmlspecial, $nl2br, $raw)

--- a/core/inc/util/GWF_Validator.php
+++ b/core/inc/util/GWF_Validator.php
@@ -10,7 +10,13 @@ final class GWF_Validator
 		if (Common::startsWith($url, '/')) {
 			return true;
 		}
+		// TODO: filter_var($url, FILTER_VALIDATE_URL); ?
 		return preg_match("/^[a-zA-Z]+[:\/\/]+[A-Za-z0-9\-_]+\\.+[A-Za-z0-9\.\/%&=\?\-_]+$/iD", $url) === 1;
+	}
+
+	public static function isAbsoluteURL($url)
+	{
+		return parse_url($url, PHP_URL_SCHEME) !== null;
 	}
 
 //	public static function filterURL($url, $maxlen=255)


### PR DESCRIPTION
Add target="_blank" only for absolute URIs. There are cases e.g. in the news system to use BBCode for local links.

Fixes: 5bf190398db24d160977e315c0bd344a5be1bfc7