### PR TITLE
Drop unused method `GWF_Message::wordwrap()`

### DIFF
--- a/core/inc/util/GWF_Message.php
+++ b/core/inc/util/GWF_Message.php
@@ -216,8 +216,6 @@ class GWF_Message {
 	 */
 	public static function display($message, $allowBB=true, $allowSmiley=true, $allowIMG=false, array $highlight=array())
 	{
-//		$message = self::wordwrap($message);
-
 		if (!$allowBB) {
 			$message = sprintf('[noparse]%s[/noparse]', $message);
 		}
@@ -239,11 +237,6 @@ class GWF_Message {
 		GWF_BBCode::initHighlighter($highlight);
 //		GWF_BB3::initSmileys(self::$bbSmileys, self::bbSmileyPath(), $allowSmiley);
 //		GWF_BB3::initHighlighter($highlight);
-	}
-
-	private static function wordwrap($string, $maxlen=72, $break="\n")
-	{
-		return preg_replace('#(\S{'.$maxlen.',})#e', "chunk_split('$1', ".$maxlen.", '".$break."')", $string); 
 	}
 
 	/**


### PR DESCRIPTION
- it is unused
- the `/e` modifier in preg_replace no longer exists since PHP 7.0

Since it is not used, I just dropped it :)