### PR TITLE
Replace dynamically generated vote buttons with CSS

### DIFF
--- a/www/tpl/default/css/gwf3.css
+++ b/www/tpl/default/css/gwf3.css
@@ -455,3 +455,11 @@ del {
 .markdown a {
 	text-decoration: none;
 }
+
+span.gfw_vote_dot {
+	height: 16px;
+	width: 16px;
+	background-color: #fff;
+	border-radius: 50%;
+	display: inline-block;
+}

--- a/www/tpl/default/module/Votes/votebutton.php
+++ b/www/tpl/default/module/Votes/votebutton.php
@@ -1,5 +1,14 @@
 <?php
-$vs = $tVars['votescore']; $vs instanceof GWF_VoteScore;
+/**
+ * @var array{
+ *     'votescore': GWF_VoteScore,
+ *     'lang': string,
+ *     'module': GWF_Module
+ *   } $tVars
+ * @var ?GWF_LangTrans $tLang
+ */
+
+$vs = $tVars['votescore'];
 $min = $vs->getVar('vs_min'); # 1
 $max = $vs->getVar('vs_max'); # 5
 $range = $max - $min + 1;
@@ -9,8 +18,12 @@ $val = $min;
 for ($i = 0; $i < $range; $i++)
 {
 	$sval = (string)$val;
-	echo sprintf('<a class="gwf_votebtn" href="%s" onclick="%s"><img src="%s" alt="%s" title="%s" /></a>', '#', $vs->getOnClick($sval), $vs->hrefButton($sval), "[$sval]", str_replace('%1%', $sval, $text));
+	printf(
+		'<a class="gwf_votebtn" href="#" onclick="%s"><span class="gfw_vote_dot" style="background-color: #%s" title="%s"></span></a>',
+		$vs->getOnClick($sval),
+		GWF_Color::interpolatBound($min, $max, $sval),
+		str_replace('%1%', $sval, $text)
+	);
 	$val++;
 }
 echo '</span>';
-?>


### PR DESCRIPTION
Unsure if the `gwf3.css` of default template is actually loaded at wechall, but works locally

<img width="839" height="290" alt="2026-07-31_170853" src="https://github.com/user-attachments/assets/2a3068e7-68bf-4271-8e69-5db449d5035c" />

Functionality the same, buttons look _slightly_ different (rounder, and without the white border)