### PR TITLE
Replace `dirname(__FILE__)` with `__DIR__`

### DIFF
--- a/GWF3.php
+++ b/GWF3.php
@@ -26,7 +26,7 @@ class GWF3
 	
 	public static function init($basepath=NULL)
 	{
-		define('GWF_PATH', dirname(__FILE__).'/');
+		define('GWF_PATH', __DIR__.'/');
 		$basepath = $basepath === NULL ? GWF_PATH.'www' : $basepath;
 		define('GWF_WWW_PATH', $basepath.'/');
 		define('GWF_CORE_PATH', GWF_PATH.'core/');

--- a/core/inc/util/GWF_Debug.php
+++ b/core/inc/util/GWF_Debug.php
@@ -102,7 +102,7 @@ final class GWF_Debug
 
 			if ($error && ($error['type'] != 0))
 			{
-				$dirname = dirname(__FILE__);
+				$dirname = __DIR__;
 				require_once $dirname.'/GWF_Log.php';
 				require_once $dirname.'/GWF_IP6.php';
 				require_once $dirname.'/GWF_Mail.php';

--- a/core/inc/util/GWF_DebugInfo.php
+++ b/core/inc/util/GWF_DebugInfo.php
@@ -19,8 +19,8 @@ class GWF_DebugInfo
 		$disk_total = $disk_free = 0;
 		if ($with_diskspace)
 		{
-			$disk_free = disk_free_space(dirname(__FILE__));
-			$disk_total = disk_total_space(dirname(__FILE__));
+			$disk_free = disk_free_space(__DIR__);
+			$disk_total = disk_total_space(__DIR__);
 		}
 
 		return array(

--- a/core/module/Audit/webspace/webspace_on.php
+++ b/core/module/Audit/webspace/webspace_on.php
@@ -48,7 +48,7 @@ if (!is_dir($dir))
 	}
 }
 
-$skeldir = dirname(__FILE__).'/skel';
+$skeldir = __DIR__.'/skel';
 foreach (scandir($skeldir) as $skel)
 {
 	if ($skel !== '.' && $skel !== '..')

--- a/core/module/Dog/Dog.php
+++ b/core/module/Dog/Dog.php
@@ -1,5 +1,5 @@
 <?php
-define('DOG_PATH', dirname(__FILE__).'/');
+define('DOG_PATH', __DIR__.'/');
 define('DOG_VERSION', '0.94a');
 require_once 'dog_include/Dog_Includes.php';
 

--- a/core/module/Dog/dog_bin/dog.php
+++ b/core/module/Dog/dog_bin/dog.php
@@ -1,5 +1,5 @@
 <?php
-chdir(dirname(__FILE__));
+chdir(__DIR__);
 chdir('../');
 
 define('DOG_WS_QUEUE', true);

--- a/core/module/Dog/dog_bin/dogdev.php
+++ b/core/module/Dog/dog_bin/dogdev.php
@@ -1,5 +1,5 @@
 <?php
-chdir(dirname(__FILE__));
+chdir(__DIR__);
 $argv = array(
 	'dogdev.php',
 	'config_dog_dev.php', 'install', 'noflush', 'noimport', 'dev', 'gizmore'

--- a/core/module/WeChall/bin/warserver.php
+++ b/core/module/WeChall/bin/warserver.php
@@ -30,7 +30,7 @@
 #
 
 
-chdir(dirname(__FILE__));
+chdir(__DIR__);
 chdir('../../../../www');
 
 # Load config

--- a/gwf3.class.php
+++ b/gwf3.class.php
@@ -237,7 +237,7 @@ class GWF3
 //		}
 
 		# Default defines
-		define('GWF_PATH', dirname(__FILE__).'/');
+		define('GWF_PATH', __DIR__.'/');
 		define('GWF_EXTRA_PATH', GWF_PATH.'extra/');
 		define('GWF_CORE_PATH', GWF_PATH.'core/');
 	


### PR DESCRIPTION
`dirname(__FILE__)` is likely a relict of PHP 5.2 times when `__DIR__` did not exist. Makes no sense nowadays.